### PR TITLE
add forpy_mod.F90 to share code and link python in ldflags

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -746,16 +746,42 @@ using a fortran linker.
 </compiler>
 
 <compiler MACH="derecho">
-  <CFLAGS>
-    <base>  -qno-opt-dynamic-align -fp-model precise -std=gnu99 </base>
-    <append MODEL="mpi-serial"> -std=gnu89 </append>
-  </CFLAGS>
   <NETCDF_PATH>$ENV{NETCDF}</NETCDF_PATH>
   <PNETCDF_PATH>$ENV{PNETCDF}</PNETCDF_PATH>
   <SLIBS>
     <append> -lnetcdff -lnetcdf </append>
   </SLIBS>
 </compiler>
+
+<compiler MACH="derecho" COMPILER="intel">
+  <CFLAGS>
+    <base>  -qno-opt-dynamic-align -fp-model precise -std=gnu99 </base>
+    <append MODEL="mpi-serial"> -std=gnu89 </append>
+    <append> -march=core-avx2 -no-fma</append>
+  </CFLAGS>
+  <FFLAGS>
+    <append> -march=core-avx2 -no-fma</append>
+  </FFLAGS>
+  <LDFLAGS>
+    <append>-L/glade/u/apps/derecho/23.09/spack/opt/spack/python/3.10.12/gcc/7.5.0/lmsy/lib  -lpython3.10</append>
+  </LDFLAGS>
+</compiler>
+
+<compiler MACH="perlmutter" >
+  <FFLAGS>
+    <append> -march=core-avx2 -no-fma</append>
+  </FFLAGS>
+  <CFLAGS>
+    <append> -march=core-avx2 -no-fma -qno-opt-dynamic-align -fp-model precise -std=gnu99 </append>
+    <append MODEL="mpi-serial"> -std=gnu89 </append>
+  </CFLAGS>
+  <SLIBS>
+    <append> -L$(NETCDF_PATH)/lib -lnetcdff -lnetcdf </append>
+    <append MODEL="^mpi-serial"> -L$(PNETCDF_PATH)/lib -lpnetcdf</append>
+  </SLIBS>
+</compiler>
+
+
 
 
 <compiler MACH="eastwind" COMPILER="intel">

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -45,7 +45,9 @@ def buildlib(bldroot, installpath, caseroot):
 ###############################################################################
     with Case(caseroot, read_only=False) as case:
         cimeroot = case.get_value("CIMEROOT")
+        srcroot = case.get_value("SRCROOT")
         filepath = [os.path.join(caseroot,"SourceMods","src.share"),
+                    os.path.join(srcroot, "forpy"),
                     os.path.join(cimeroot,"src","drivers","mct","shr"),
                     os.path.join(cimeroot,"src","share","streams"),
                     os.path.join(cimeroot,"src","share","util"),


### PR DESCRIPTION
I decided to do this via pull requests so you can see what I've changed.
This adds forpy_mod.F90 to the share code where it's available to all components.  

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
